### PR TITLE
User authorization

### DIFF
--- a/foodji_api/Api/Controllers/RecipesController.cs
+++ b/foodji_api/Api/Controllers/RecipesController.cs
@@ -1,6 +1,8 @@
 using Application.Command;
 using Application.Dto;
 using Application.Queries;
+using Auth;
+using Auth.Policies;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -13,20 +15,36 @@ namespace Api.Controllers;
 public class RecipesController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly IAuthorizationService _authorizationService;
     
-    public RecipesController(IMediator mediator)
+    public RecipesController(IMediator mediator, IAuthorizationService authorizationService)
     {
         _mediator = mediator;
+        _authorizationService = authorizationService;
     }
+
 
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<RecipeDto>))]
     public async Task<IActionResult> GetAllRecipes()
     {
-        var query = new GetAllRecipesQuery();
+        var userId = User.Claims.First(x => x.Type == "user_id").Value;
+        var query = new GetAllRecipesFromUserQuery(userId);
+        
+        // TODO refactor eventually with query param for public + user's
+        // TODO currently disabled the get *all* even for admins, probably also a query param eventually
+        // var query = new GetAllRecipesQuery();
         
         var result =  await _mediator.Send(query);
         
+        // TODO bit of a particular case here, and can be reviewed with refactor
+        // but if null, it's the user who isn't found, so we return a 401
+        // Should be impossible, because of the authorization requirements
+        if (result == null)
+        {
+            return Unauthorized();
+        }
+
         return Ok(result);
     }
 
@@ -35,24 +53,16 @@ public class RecipesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetRecipe([FromRoute] string id)
     {
-        var query = new GetRecipeByIdQuery(id);
+        // Check access rights
+        var authResult = await Authorize(id, FoodjiRecipeAccessRequirement.Policy);
 
-        var result = await _mediator.Send(query);
-
-        if (result == null)
+        if (!authResult.Succeeded)
         {
-            return NotFound();
+            return Forbid();
         }
-
-        return Ok(result);
-    }
-    
-    [HttpGet("users/{id}")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<RecipeDto>))]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetAllRecipesFromUser([FromRoute] string id)
-    {
-        var query = new GetAllRecipesFromUserQuery(id);
+        
+        // Get the recipe
+        var query = new GetRecipeByIdQuery(id);
 
         var result = await _mediator.Send(query);
 
@@ -68,6 +78,9 @@ public class RecipesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     public async Task<IActionResult> CreateRecipe([FromBody] RecipeDto recipe)
     {
+        // Get the author's user id from the authentication context
+        recipe.Author = User.Claims.First(x => x.Type == "user_id").Value;
+        
         var command = new CreateRecipeCommand(recipe);
 
         var result = await _mediator.Send(command);
@@ -80,6 +93,15 @@ public class RecipesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateRecipe([FromBody] RecipeDto recipe)
     {
+        // Check access rights
+        // TODO refactor so the id is in the route, NOT the DTO (nullable warning)
+        var authResult = await Authorize(recipe.Id!, FoodjiRecipeAccessRequirement.Policy);
+
+        if (!authResult.Succeeded)
+        {
+            return Forbid();
+        }
+        
         var command = new UpdateRecipeCommand(recipe);
 
         var result = await _mediator.Send(command);
@@ -97,6 +119,14 @@ public class RecipesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteRecipe([FromRoute] string id)
     {
+        // Check access rights
+        var authResult = await Authorize(id, FoodjiRecipeAccessRequirement.Policy);
+
+        if (!authResult.Succeeded)
+        {
+            return Forbid();
+        }
+        
         var command = new DeleteRecipeCommand(id);
 
         var result = await _mediator.Send(command);
@@ -107,5 +137,20 @@ public class RecipesController : ControllerBase
         }
 
         return NoContent();
+    }
+
+    /// <summary>
+    /// Convenience method to wrap getting the recipe details from its id to check against a policy.
+    /// </summary>
+    /// <param name="recipeId">The id of the recipe against which to check authorization.</param>
+    /// <param name="policy">The name of the policy by which to evaluate authorization.</param>
+    /// <returns>The resulting <see cref="AuthorizationResult"/></returns>
+    private async Task<AuthorizationResult> Authorize(string recipeId, string policy)
+    {
+        var accessRightsQuery = new GetRecipeAccessRightsQuery(recipeId);
+        var recipeAccessRights = await _mediator.Send(accessRightsQuery);
+        
+        return await _authorizationService
+            .AuthorizeAsync(User, recipeAccessRights, policy);
     }
 }

--- a/foodji_api/Api/Controllers/RecipesController.cs
+++ b/foodji_api/Api/Controllers/RecipesController.cs
@@ -1,7 +1,6 @@
 using Application.Command;
 using Application.Dto;
 using Application.Queries;
-using Auth;
 using Auth.Policies;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -23,7 +22,6 @@ public class RecipesController : ControllerBase
         _authorizationService = authorizationService;
     }
 
-
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<RecipeDto>))]
     public async Task<IActionResult> GetAllRecipes()
@@ -36,14 +34,6 @@ public class RecipesController : ControllerBase
         // var query = new GetAllRecipesQuery();
         
         var result =  await _mediator.Send(query);
-        
-        // TODO bit of a particular case here, and can be reviewed with refactor
-        // but if null, it's the user who isn't found, so we return a 401
-        // Should be impossible, because of the authorization requirements
-        if (result == null)
-        {
-            return Unauthorized();
-        }
 
         return Ok(result);
     }

--- a/foodji_api/Api/Program.cs
+++ b/foodji_api/Api/Program.cs
@@ -48,7 +48,10 @@ builder.Services.SetupInfra(
 
 builder.Services.AddMediatR(Assembly.Load("Application"));
 builder.Services.AddAutoMapper(Assembly.Load("Application"));
+
+// Keep these two in order
 builder.Services.AddFirebaseJwtAuthentication(builder.Configuration);
+builder.Services.AddFoodjiAuthorization();
 
 var app = builder.Build();
 

--- a/foodji_api/Application/Converters/RecipeConverter.cs
+++ b/foodji_api/Application/Converters/RecipeConverter.cs
@@ -29,6 +29,7 @@ public class RecipeConverter : ITypeConverter<RecipeDto, Recipe>
             ingredients,
             source.Steps.ToList(),
             source.ImageUri,
-            source.Author);
+            // Shouldn't happen, as is set from auth context in controller
+            source.Author ?? throw new ArgumentException("Author id has not been set"));
     }
 }

--- a/foodji_api/Application/Dto/RecipeAccessRightsDto.cs
+++ b/foodji_api/Application/Dto/RecipeAccessRightsDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Application.Dto;
+
+public class RecipeAccessRightsDto
+{
+    // Used exclusively for authorization purposes
+    // This is a structure so we can eventually extend it to add things such as public read access,
+    // or different edit rights structures (co-author, editors?)
+    public string AuthorId { get; init; }
+}

--- a/foodji_api/Application/Dto/RecipeAccessRightsDto.cs
+++ b/foodji_api/Application/Dto/RecipeAccessRightsDto.cs
@@ -5,5 +5,5 @@ public class RecipeAccessRightsDto
     // Used exclusively for authorization purposes
     // This is a structure so we can eventually extend it to add things such as public read access,
     // or different edit rights structures (co-author, editors?)
-    public string AuthorId { get; init; }
+    public string? AuthorId { get; init; }
 }

--- a/foodji_api/Application/Dto/RecipeDto.cs
+++ b/foodji_api/Application/Dto/RecipeDto.cs
@@ -20,5 +20,5 @@ public record RecipeDto
     
     public Uri ImageUri { get; set; } = null!;
     
-    public string Author { get; set; } = null!;
+    public string? Author { get; set; } = null!;
 }

--- a/foodji_api/Application/Queries/GetAllRecipesFromUserQuery.cs
+++ b/foodji_api/Application/Queries/GetAllRecipesFromUserQuery.cs
@@ -27,10 +27,12 @@ public class GetAllRecipesFromUserQuery : IRequest<IEnumerable<RecipeDto>?>
             _mapper = mapper;
         }
 
-        public async Task<IEnumerable<RecipeDto>?> Handle(GetAllRecipesFromUserQuery request, CancellationToken cancellationToken)
+        public async Task<IEnumerable<RecipeDto>?> Handle(
+            GetAllRecipesFromUserQuery request, 
+            CancellationToken cancellationToken)
         {
-            // TODO: We should index the AuthorId field
-            var results = await _client.Recipes.FindAsync(x => x.Author == request.AuthorId, cancellationToken: cancellationToken);
+            var results = await _client.Recipes.FindAsync(
+                x => x.Author == request.AuthorId, cancellationToken: cancellationToken);
             
             var recipes = results.ToList();
             

--- a/foodji_api/Application/Queries/GetAllRecipesFromUserQuery.cs
+++ b/foodji_api/Application/Queries/GetAllRecipesFromUserQuery.cs
@@ -34,9 +34,8 @@ public class GetAllRecipesFromUserQuery : IRequest<IEnumerable<RecipeDto>>
             var results = await _client.Recipes.FindAsync(
                 x => x.Author == request.AuthorId, cancellationToken: cancellationToken);
             
-            var recipes = results.ToList(cancellationToken: cancellationToken);
-
-            return _mapper.Map<IEnumerable<Recipe>, IEnumerable<RecipeDto>>(recipes.ToList());
+            return _mapper.Map<IEnumerable<Recipe>, IEnumerable<RecipeDto>>(
+                results.ToList(cancellationToken: cancellationToken));
         }
     }
 }

--- a/foodji_api/Application/Queries/GetAllRecipesFromUserQuery.cs
+++ b/foodji_api/Application/Queries/GetAllRecipesFromUserQuery.cs
@@ -7,7 +7,7 @@ using MongoDB.Driver;
 
 namespace Application.Queries;
 
-public class GetAllRecipesFromUserQuery : IRequest<IEnumerable<RecipeDto>?>
+public class GetAllRecipesFromUserQuery : IRequest<IEnumerable<RecipeDto>>
 {
     private string AuthorId { get; }
 
@@ -16,7 +16,7 @@ public class GetAllRecipesFromUserQuery : IRequest<IEnumerable<RecipeDto>?>
         AuthorId = authorId;
     }
     
-    private class Handler : IRequestHandler<GetAllRecipesFromUserQuery, IEnumerable<RecipeDto>?>
+    private class Handler : IRequestHandler<GetAllRecipesFromUserQuery, IEnumerable<RecipeDto>>
     {
         private readonly IFoodjiDbClient _client;
         private readonly IMapper _mapper;
@@ -27,19 +27,14 @@ public class GetAllRecipesFromUserQuery : IRequest<IEnumerable<RecipeDto>?>
             _mapper = mapper;
         }
 
-        public async Task<IEnumerable<RecipeDto>?> Handle(
+        public async Task<IEnumerable<RecipeDto>> Handle(
             GetAllRecipesFromUserQuery request, 
             CancellationToken cancellationToken)
         {
             var results = await _client.Recipes.FindAsync(
                 x => x.Author == request.AuthorId, cancellationToken: cancellationToken);
             
-            var recipes = results.ToList();
-            
-            if (recipes.Count == 0)
-            {
-                return null;
-            }
+            var recipes = results.ToList(cancellationToken: cancellationToken);
 
             return _mapper.Map<IEnumerable<Recipe>, IEnumerable<RecipeDto>>(recipes.ToList());
         }

--- a/foodji_api/Application/Queries/GetRecipeAccessRightsQuery.cs
+++ b/foodji_api/Application/Queries/GetRecipeAccessRightsQuery.cs
@@ -1,0 +1,46 @@
+﻿using Application.Dto;
+using AutoMapper;
+using Domain.Recipes;
+using Infra;
+using MediatR;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Application.Queries;
+
+public class GetRecipeAccessRightsQuery : IRequest<RecipeAccessRightsDto?>
+{
+    private string RecipeId { get; }
+
+    public GetRecipeAccessRightsQuery(string recipeId)
+    {
+        RecipeId = recipeId;
+    }
+    
+    private class Handler : IRequestHandler<GetRecipeAccessRightsQuery, RecipeAccessRightsDto?>
+    {
+        private readonly IFoodjiDbClient _client;
+
+        public Handler(IFoodjiDbClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<RecipeAccessRightsDto?> Handle(GetRecipeAccessRightsQuery request, CancellationToken cancellationToken)
+        {
+            // Safe parsing the string into an ObjectId. Return null if the id is malformed
+            ObjectId id;
+            if (!ObjectId.TryParse(request.RecipeId, out id))
+            {
+                return null;
+            }
+            
+            var results = await _client.Recipes.FindAsync(
+                x => x.Id == id, cancellationToken: cancellationToken);
+
+            var recipe = results.SingleOrDefault(cancellationToken: cancellationToken);
+
+            return recipe == null ? null : new RecipeAccessRightsDto{ AuthorId = recipe.Author };
+        }
+    }
+}

--- a/foodji_api/Application/Queries/GetRecipeAccessRightsQuery.cs
+++ b/foodji_api/Application/Queries/GetRecipeAccessRightsQuery.cs
@@ -29,8 +29,7 @@ public class GetRecipeAccessRightsQuery : IRequest<RecipeAccessRightsDto?>
         public async Task<RecipeAccessRightsDto?> Handle(GetRecipeAccessRightsQuery request, CancellationToken cancellationToken)
         {
             // Safe parsing the string into an ObjectId. Return null if the id is malformed
-            ObjectId id;
-            if (!ObjectId.TryParse(request.RecipeId, out id))
+            if (!ObjectId.TryParse(request.RecipeId, out var id))
             {
                 return null;
             }

--- a/foodji_api/Auth/Auth.csproj
+++ b/foodji_api/Auth/Auth.csproj
@@ -22,5 +22,9 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Application\Application.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/foodji_api/Auth/Extensions/IServiceCollectionExtension.cs
+++ b/foodji_api/Auth/Extensions/IServiceCollectionExtension.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
+using Auth.Policies;
 using FirebaseAdmin;
 using Google.Apis.Auth.OAuth2;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -30,5 +32,16 @@ public static class ServiceCollectionExtension
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddScheme<FirebaseAuthenticationSchemeOptions, FirebaseAuthenticationHandler>(
                 JwtBearerDefaults.AuthenticationScheme, null);
+    }
+
+    public static void AddFoodjiAuthorization(this IServiceCollection services)
+    {
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(FoodjiRecipeAccessRequirement.Policy, policy =>
+                policy.Requirements.Add(new FoodjiRecipeAccessRequirement()));
+        });
+
+        services.AddSingleton<IAuthorizationHandler, FoodjiAuthorizationHandler>();
     }
 }

--- a/foodji_api/Auth/Policies/FoodjiAuthorizationHandler.cs
+++ b/foodji_api/Auth/Policies/FoodjiAuthorizationHandler.cs
@@ -1,0 +1,29 @@
+﻿using Application.Dto;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Auth.Policies;
+
+public class FoodjiAuthorizationHandler : AuthorizationHandler<FoodjiRecipeAccessRequirement, RecipeAccessRightsDto>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        FoodjiRecipeAccessRequirement requirement,
+        RecipeAccessRightsDto recipe)
+    {
+        // Precheck which automatically grants access if the user has an admin claim
+        if (context.User.HasClaim(x => x.Type == "admin" && x.Value == "true"))
+        {
+            context.Succeed(requirement);
+        }
+        
+        // Extract user id
+        var authorId = context.User.Claims.First(x => x.Type == "user_id").Value;
+
+        if (authorId == recipe.AuthorId)
+        {
+            context.Succeed(requirement);
+        }
+        
+        return Task.CompletedTask;
+    }
+}

--- a/foodji_api/Auth/Policies/FoodjiRecipeAccessRequirement.cs
+++ b/foodji_api/Auth/Policies/FoodjiRecipeAccessRequirement.cs
@@ -7,5 +7,5 @@ namespace Auth.Policies;
 // of action (read, update, delete)
 public class FoodjiRecipeAccessRequirement : IAuthorizationRequirement
 {
-    public static readonly string Policy = "ReadRecipePolicy";
+    public const string Policy = "ReadRecipePolicy";
 }

--- a/foodji_api/Auth/Policies/FoodjiRecipeAccessRequirement.cs
+++ b/foodji_api/Auth/Policies/FoodjiRecipeAccessRequirement.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Auth.Policies;
+
+// TODO this is very generic, and suitable pre-sharing, but should be extended with
+// a suite of policies to handle ownership, sharing and admin rights on a variety
+// of action (read, update, delete)
+public class FoodjiRecipeAccessRequirement : IAuthorizationRequirement
+{
+    public static readonly string Policy = "ReadRecipePolicy";
+}


### PR DESCRIPTION
Finally actual authorization, so users only have access to their own recipes.

Implements authorization handler with a custom policy, and adds authorization checks where relevant.
Does not cover authorization variations such as admin rights or concepts of public recipes. Those can follow later on.

Also removes the "GetAllRecipes" endpoint, as can now by default get the user's recipes. We can later on add a query parameter and additional authorization for admins to get *all* recipes regardless of author or status, if we feel the need (but it's not like we have an admin view where it would be useful at the moment either, and raw data is just as easily accessible in the DB for our purposes at the moment...)